### PR TITLE
Minor improvements to code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 /dist
 /O2
 /__pycache__
+/modules/__pycache__
+/objects/__pycache__
 README.md
 Entitlements.plist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build
 /dist
 /O2
+/__pycache__
 README.md
 Entitlements.plist

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /build
 /dist
 /O2
-/__pycache__
-/modules/__pycache__
-/objects/__pycache__
+__pycache__/
 README.md
 Entitlements.plist

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -336,10 +336,6 @@ class O2PTSolver():
 
     def solveDO2(self, VO2, PvO2):
         VO2Unit = self.d['VO2_unit']
-        try:
-            DO2 = float(self.d['DO2'])
-        except ValueError:
-            DO2 = 0
         
         try:
             k = float(self.d['k'])
@@ -350,15 +346,10 @@ class O2PTSolver():
         # self.w.setMC('DO2_MC', 1)
 
         try:
-            if DO2 == 0:
-                if VO2Unit == 'ml/min': # -> l/min
-                    VO2 = VO2 / 1000
+            if VO2Unit == 'ml/min': # -> l/min
+                VO2 = VO2 / 1000
                 
-                # return VO2 / 2 / PvO2 * 1000
-                return [VO2 / k / PvO2 * 1000, VO2 / k / PvO2 * 1000]
-            else:
-                return [DO2, VO2 / k / PvO2 * 1000]
-                # return VO2 / k / PvO2 * 1000
+            return VO2 / 2 / PvO2 * 1000
         except:
             self.validValues = False
             return self.validValues
@@ -399,13 +390,12 @@ class O2PTSolver():
             return self.validValues
         PvO2_corrected = self.phTempCorrection(pH0, pH, T0, T, PvO2_calc)
 
-        [DO2, DO2_graph] = self.solveDO2(VO2, PvO2_corrected) # Two values to improve graphical display accuracy
+        DO2 = self.solveDO2(VO2, PvO2_corrected)
 
         # Calculate datapoints for diffusion line
         PvO2 = np.arange(0.0, 100.01, 0.1)
         k = float(self.d['k'])
-        # y = k * DO2 * PvO2
-        y = k * DO2_graph * PvO2
+        y = k * DO2 * PvO2
 
         # Convert to l/min
         if self.d['Q_unit'] == 'ml/min':

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -316,7 +316,7 @@ class O2PTSolver():
             return self.validValues
 
     def phTempCorrection(self, pH0, pH, T0, T, PvO2):
-        lnPvO2 = np.log(PvO2)
+        # lnPvO2 = np.log(PvO2)
 
         if pH != pH0 or T != T0:
             lnPO2pH = (pH - pH0) * (-1.1)
@@ -325,7 +325,7 @@ class O2PTSolver():
             lnPO2pH = 0
             lnPO2Temp = 0
 
-        PvO2 = np.exp( lnPvO2 + lnPO2Temp + lnPO2pH )
+        PvO2 *= np.exp(lnPO2Temp + lnPO2pH)
 
         return PvO2
 
@@ -394,7 +394,7 @@ class O2PTSolver():
 
         # Calculate diffusion DO2
         a = 11700.0/(1.0/SvO2 - 1)
-        b = np.sqrt( 50**3 + a**2)
+        b = np.sqrt(50**3 + a**2)
         PvO2_calc = self.formatPvO2(a, b) # mmHg
 
         if PvO2_calc < 0:
@@ -443,8 +443,8 @@ class O2PTSolver():
         [DO2, DO2_graph] = self.solveDO2(VO2, PvO2_corrected) # Two values to improve graphical display accuracy
 
         # Compute the coefficient for convection curve shift
-        PvO2_coef = PvO2_corrected/PvO2_calc
-        PvO2_err = PvO2_corrected-PvO2_calc
+        # PvO2_coef = PvO2_corrected/PvO2_calc
+        # PvO2_err = PvO2_corrected-PvO2_calc
 
         # Calculate datapoints for diffusion line
         PvO2 = np.arange(0.0, 100.01, 0.1)
@@ -481,6 +481,6 @@ class O2PTSolver():
 
         SvO2 = SvO2 * 100
 
-        self.w.setCalcResults(y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, T0, T, pH0, pH, PvO2_corrected, DO2, PvO2_coef, PvO2_err)
+        self.w.setCalcResults(y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, T0, T, pH0, pH, PvO2_corrected, DO2) #, PvO2_coef, PvO2_err)
 
         return self.validValues

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -4,7 +4,6 @@ class O2PTSolver():
     def __init__(self, workloadObject, detailsDict):
         self.w = workloadObject
         self.d = detailsDict
-        self.preventCorrection = False
         self.validValues = True
 
     def formatQ(self):
@@ -305,12 +304,7 @@ class O2PTSolver():
         self.w.setMC('PvO2_MC', 1)
         
         try:
-            if PvO2 == 0:
-                return np.float_power( a+b, (1/3)) - np.float_power( b-a, (1/3))
-            else:
-                # self.preventCorrection = True
-                # return PvO2
-                return np.float_power( a+b, (1/3)) - np.float_power( b-a, (1/3))
+            return (a + b)**(1/3.0) - (b - a)**(1/3.0)
         except:
             self.validValues = False
             return self.validValues
@@ -369,13 +363,6 @@ class O2PTSolver():
             self.validValues = False
             return self.validValues
 
-    def solveP50(self, pH0, pH, T0, T):
-        p50S = 26.86
-        p50pH = p50S-25.535*(pH-pH0)+10.646*(pH-pH0)**2-1.764*(pH-pH0)**3
-        p50T = p50S+1.435*(T-T0) + np.float_power(4.163, -2)*(T-T0)**2 + np.float_power(6.86, -4)*(T-T0)**3
-        p50 = p50S * (p50pH/p50S) * (p50T/p50S)
-        return p50
-
     def calc(self): #w=workload object, details=dict
         # validValues = True
         Q = self.formatQ()
@@ -410,17 +397,9 @@ class O2PTSolver():
         except:
             self.validValues = False
             return self.validValues
-
-        if self.preventCorrection:
-            PvO2_corrected = PvO2_calc
-        else:
-            PvO2_corrected = self.phTempCorrection(pH0, pH, T0, T, PvO2_calc)
+        PvO2_corrected = self.phTempCorrection(pH0, pH, T0, T, PvO2_calc)
 
         [DO2, DO2_graph] = self.solveDO2(VO2, PvO2_corrected) # Two values to improve graphical display accuracy
-
-        # Compute the coefficient for convection curve shift
-        # PvO2_coef = PvO2_corrected/PvO2_calc
-        # PvO2_err = PvO2_corrected-PvO2_calc
 
         # Calculate datapoints for diffusion line
         PvO2 = np.arange(0.0, 100.01, 0.1)
@@ -457,6 +436,6 @@ class O2PTSolver():
 
         SvO2 = SvO2 * 100
 
-        self.w.setCalcResults(y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, T0, T, pH0, pH, PvO2_corrected, DO2) #, PvO2_coef, PvO2_err)
+        self.w.setCalcResults(y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, T0, T, pH0, pH, PvO2_corrected, DO2)
 
         return self.validValues

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -393,8 +393,8 @@ class O2PTSolver():
         QaO2 = self.formatQaO2(Q, CaO2)
 
         # Calculate diffusion DO2
-        a = 11700 * np.float_power( ( np.float_power(SvO2,-1) - 1 ), -1 )
-        b = np.float_power( 50**3 + np.float_power(a,2), 0.5 )
+        a = 11700.0/(1.0/SvO2 - 1)
+        b = np.sqrt( 50**3 + a**2)
         PvO2_calc = self.formatPvO2(a, b) # mmHg
 
         if PvO2_calc < 0:
@@ -447,7 +447,7 @@ class O2PTSolver():
         PvO2_err = PvO2_corrected-PvO2_calc
 
         # Calculate datapoints for diffusion line
-        PvO2 = np.arange(0.01,100.01,0.1)
+        PvO2 = np.arange(0.0, 100.01, 0.1)
         k = float(self.d['k'])
         # y = k * DO2 * PvO2
         y = k * DO2_graph * PvO2
@@ -460,7 +460,7 @@ class O2PTSolver():
             Hb = Hb / 10
 
         # Calculate datapoints for convective curve
-        y2 = lambda x: Q * 1.34 * Hb * (SaO2/100 - 1/((23400/(np.float_power(x,3)+150*x))+1))*10
+        y2 = lambda x: Q * 1.34 * Hb * (SaO2/100 - (x**3 + 150*x)/(x**3 + 150*x + 23400))*10
         x2 = self.phTempCorrection(pH, pH0, T, T0, PvO2)
         y2 = y2(x2)
         

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -413,32 +413,8 @@ class O2PTSolver():
 
         if self.preventCorrection:
             PvO2_corrected = PvO2_calc
-            # p50 = self.d['p50']
         else:
-            # Modeling from 37/7.4 -> 38.5/7.03 should produce same results as 38.5/7.03
-            if (pH0 == pH and T0 == T):
-                # If no change in pH or T values, check if normal physiological conditions
-                if pH0 != 7.4 and T0 == 37:
-                    PvO2_corrected = self.phTempCorrection(7.4, pH, T0, T, PvO2_calc)
-                    # p50 = self.solveP50(7.4, pH, T0, T)
-                elif T0 != 37 and pH0 == 7.4:
-                    PvO2_corrected = self.phTempCorrection(pH0, pH, 37, T, PvO2_calc)
-                    # p50 = self.solveP50(pH0, pH, 37, T)
-                else:
-                    PvO2_corrected = self.phTempCorrection(7.4, pH, 37, T, PvO2_calc)
-                    # p50 = self.solveP50(7.4, pH, 37, T)
-            elif pH0 != 7.4 or T0 != 37:
-                # If initial values for pH/T are different than physiological normals e.g. pH0= 7.2
-                # E.g. 7.2/37.5 -> 7.0/39
-                # Correct first to normal physiological conditions
-                PvO2_corrected = self.phTempCorrection(7.4, pH0, 37, T0, PvO2_calc)
-                # Then to the final peak value
-                PvO2_corrected = self.phTempCorrection(7.4, pH, 37, T, PvO2_corrected)
-                # p50 = self.solveP50(7.4, pH, 37, T)
-            else:
-                # If initial values are equal to normal physiological conditions
-                PvO2_corrected = self.phTempCorrection(pH0, pH, T0, T, PvO2_calc)
-                # p50 = self.solveP50(pH0, pH, T0, T)
+            PvO2_corrected = self.phTempCorrection(pH0, pH, T0, T, PvO2_calc)
 
         [DO2, DO2_graph] = self.solveDO2(VO2, PvO2_corrected) # Two values to improve graphical display accuracy
 

--- a/modules/O2PTSolver.py
+++ b/modules/O2PTSolver.py
@@ -335,20 +335,10 @@ class O2PTSolver():
             return T
 
     def solveDO2(self, VO2, PvO2):
-        VO2Unit = self.d['VO2_unit']
-        
-        try:
-            k = float(self.d['k'])
-        except ValueError:
-            self.validValues = False
-            return self.validValues
-        
-        # self.w.setMC('DO2_MC', 1)
-
+        VO2Unit = self.d['VO2_unit']     
         try:
             if VO2Unit == 'ml/min': # -> l/min
-                VO2 = VO2 / 1000
-                
+                VO2 = VO2 / 1000                
             return VO2 / 2 / PvO2 * 1000
         except:
             self.validValues = False

--- a/modules/panel_plotting.py
+++ b/modules/panel_plotting.py
@@ -365,7 +365,7 @@ class PlotTab(ttk.Frame):
         self.plot[0].canvas.draw()
 
     def createPlot(self):
-        PvO2 = np.arange(0.01,100.01,0.1)
+        PvO2 = np.arange(0.0,100.01,0.1)
         self.plot = plt.subplots(constrained_layout=True)
         self.fig, self.ax = self.plot
 

--- a/objects/workLoadDetails.py
+++ b/objects/workLoadDetails.py
@@ -25,8 +25,6 @@ class WorkLoadDetails(object):
         self.pH = testDefaults['pH']
         self.PaO2 = 0
         self.PvO2 = 0
-        # self.PvO2_coef = 0
-        # self.PvO2_err = 0
         self.DO2 = 0
         self.p50 = 0
         self.k = testDefaults['k']
@@ -367,7 +365,7 @@ class WorkLoadDetails(object):
             'yi': self.yi
         }
 
-    def setCalcResults(self, y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, Trest, T, pHrest, pH, PvO2, DO2): #, PvO2_coef, PvO2_err):
+    def setCalcResults(self, y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, Trest, T, pHrest, pH, PvO2, DO2):
         self.y = y
         self.y2 = y2
         self.xi = xi
@@ -386,10 +384,7 @@ class WorkLoadDetails(object):
         self.pHrest = pHrest
         self.pH = pH
         self.PvO2 = PvO2
-        # self.PvO2_coef = PvO2_coef
-        # self.PvO2_err = PvO2_err
         self.DO2 = DO2
-        # self.p50 = p50
 
     def setImported(self, bool):
         self.isImported = bool

--- a/objects/workLoadDetails.py
+++ b/objects/workLoadDetails.py
@@ -25,8 +25,8 @@ class WorkLoadDetails(object):
         self.pH = testDefaults['pH']
         self.PaO2 = 0
         self.PvO2 = 0
-        self.PvO2_coef = 0
-        self.PvO2_err = 0
+        # self.PvO2_coef = 0
+        # self.PvO2_err = 0
         self.DO2 = 0
         self.p50 = 0
         self.k = testDefaults['k']
@@ -367,7 +367,7 @@ class WorkLoadDetails(object):
             'yi': self.yi
         }
 
-    def setCalcResults(self, y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, Trest, T, pHrest, pH, PvO2, DO2, PvO2_coef, PvO2_err):
+    def setCalcResults(self, y, y2, xi, yi, VO2, Q, Hb, SaO2, CaO2, SvO2, CvO2, CavO2, QaO2, Trest, T, pHrest, pH, PvO2, DO2): #, PvO2_coef, PvO2_err):
         self.y = y
         self.y2 = y2
         self.xi = xi
@@ -386,8 +386,8 @@ class WorkLoadDetails(object):
         self.pHrest = pHrest
         self.pH = pH
         self.PvO2 = PvO2
-        self.PvO2_coef = PvO2_coef
-        self.PvO2_err = PvO2_err
+        # self.PvO2_coef = PvO2_coef
+        # self.PvO2_err = PvO2_err
         self.DO2 = DO2
         # self.p50 = p50
 


### PR DESCRIPTION
First, the Severinghaus' O2 dissolution curve is changed to numerically better format to handle also PvO2 = 0 values.
Second, unused codes for PvO2_coef and PvO2_err were commented out in calc(), setCalcResults(), and class WorkLoadDetails(). This seems to work fine.
Thirdly, in O2PTsolver > phTempCorrection function was calculate np.log(PvO2). If PvO2 is allowed to have also 0 values, the code needed to be changed to avoid np.log(0). Thus the return value was changed to PvO2 *= np.exp(lnPO2Temp + lnPO2pH) which is mathematically same as the original code.